### PR TITLE
ENH Tidy up build tables

### DIFF
--- a/app/src/Misc/CmsBuildsManager.php
+++ b/app/src/Misc/CmsBuildsManager.php
@@ -81,6 +81,11 @@ class CmsBuildsManager
      */
     private array $locksteppedRepos = [];
 
+    /**
+     * @var array<string, array<string, string[]>> repo => [cmsMajor => moduleMajors[]]
+     */
+    private array $supportedModuleMajorMappings = [];
+
     private bool $isLoaded = false;
 
     /**
@@ -124,6 +129,7 @@ class CmsBuildsManager
 
         $this->installerToRepoMinorVersions = $this->parseInstallerToRepoMinorVersions($constsPhp);
         $this->cmsMajorToVersions = $this->deriveVisibleCmsVersions($roadmapJson->data);
+        $this->supportedModuleMajorMappings = $this->loadSupportedModuleMajorMappings($refetch);
         $this->locksteppedRepos = $this->loadLocksteppedRepos($refetch);
         $this->isLoaded = true;
     }
@@ -164,6 +170,11 @@ class CmsBuildsManager
                     $repos[$repo] = true;
                 }
             }
+            foreach ($this->supportedModuleMajorMappings as $repo => $mapping) {
+                if (isset($mapping[$cmsMajor])) {
+                    $repos[$repo] = true;
+                }
+            }
         }
         return array_keys($repos);
     }
@@ -180,7 +191,12 @@ class CmsBuildsManager
             $moduleMajors = $this->locksteppedRepos[$repo][$cmsMajor] ?? [];
             return array_map(fn(string $major) => "$major.$cmsMinor", $moduleMajors);
         }
-        return $this->normaliseVersionList($this->installerToRepoMinorVersions[$cmsVersion][$repo] ?? null);
+        $minorBranches = $this->normaliseVersionList($this->installerToRepoMinorVersions[$cmsVersion][$repo] ?? null);
+        if ($minorBranches !== []) {
+            return $minorBranches;
+        }
+        [$cmsMajor] = explode('.', $cmsVersion, 2);
+        return $this->supportedModuleMajorMappings[$repo][$cmsMajor] ?? [];
     }
 
     /**
@@ -379,36 +395,105 @@ class CmsBuildsManager
      *
      * @return array<string, array<string, string[]>>
      */
+    /**
+     * Returns raw repository metadata items from the supported-modules package.
+     * Extracted to a protected method so tests can override without network calls.
+     */
+    protected function fetchAllRepositoryMetaData(bool $refetch): array
+    {
+        return MetaData::getAllRepositoryMetaData(false, $refetch);
+    }
+
     protected function loadLocksteppedRepos(bool $refetch): array
     {
         $result = [];
-        $allItems = MetaData::getAllRepositoryMetaData(false, $refetch);
+        $allItems = $this->fetchAllRepositoryMetaData($refetch);
         foreach ($allItems as $item) {
             if (!is_array($item) || !($item['lockstepped'] ?? false)) {
                 continue;
             }
-            $github = is_string($item['github'] ?? null) ? $item['github'] : '';
-            if ($github === '' || !str_contains($github, '/')) {
+            $repo = $this->extractRepoName($item);
+            if ($repo === '') {
                 continue;
             }
-            [, $repo] = explode('/', $github, 2);
-            $rawMapping = is_array($item['majorVersionMapping'] ?? null) ? $item['majorVersionMapping'] : [];
-            if (empty($rawMapping)) {
-                continue;
-            }
-            $mapping = [];
-            foreach ($rawMapping as $cmsMajor => $moduleMajors) {
-                $mapping[(string) $cmsMajor] = array_values(array_filter(
-                    array_map('strval', (array) $moduleMajors),
-                    fn (string $major): bool => $major !== ''
-                ));
-            }
+            $mapping = $this->normaliseMajorVersionMapping(
+                is_array($item['majorVersionMapping'] ?? null) ? $item['majorVersionMapping'] : []
+            );
             if ($mapping === []) {
                 continue;
             }
             $result[$repo] = $mapping;
         }
         return $result;
+    }
+
+    /**
+     * Loads repo -> CMS major -> module major mappings for all supported-module repos that
+     * explicitly declare CMS-major compatibility, even when they are not lockstepped.
+     *
+     * @return array<string, array<string, string[]>>
+     */
+    protected function loadSupportedModuleMajorMappings(bool $refetch): array
+    {
+        // Repos that have a packagist entry but are not real installable modules.
+        $excluded = ['silverstripe-module'];
+
+        $result = [];
+        $allItems = $this->fetchAllRepositoryMetaData($refetch);
+        foreach ($allItems as $item) {
+            if (!is_array($item) || !is_string($item['packagist'] ?? null)) {
+                continue;
+            }
+            $repo = $this->extractRepoName($item);
+            if ($repo === '' || in_array($repo, $excluded, true)) {
+                continue;
+            }
+            $mapping = $this->normaliseMajorVersionMapping(
+                is_array($item['majorVersionMapping'] ?? null) ? $item['majorVersionMapping'] : []
+            );
+            if ($mapping === []) {
+                continue;
+            }
+            $result[$repo] = $mapping;
+        }
+        return $result;
+    }
+
+    /**
+     * Extracts the repository name from a supported-modules metadata record.
+     */
+    private function extractRepoName(array $item): string
+    {
+        $github = is_string($item['github'] ?? null) ? $item['github'] : '';
+        if ($github === '' || !str_contains($github, '/')) {
+            return '';
+        }
+        [, $repo] = explode('/', $github, 2);
+        return $repo;
+    }
+
+    /**
+     * Filters a supported-modules majorVersionMapping down to supported CMS majors with branch data.
+     *
+     * @return array<string, string[]>
+     */
+    private function normaliseMajorVersionMapping(array $rawMapping): array
+    {
+        $mapping = [];
+        foreach ($rawMapping as $cmsMajor => $moduleMajors) {
+            $cmsMajor = (string) $cmsMajor;
+            if (
+                $cmsMajor === '*' ||
+                version_compare($cmsMajor, MetaData::LOWEST_SUPPORTED_CMS_MAJOR, '<')
+            ) {
+                continue;
+            }
+            $mapping[$cmsMajor] = $this->sortVersionsDescending(array_values(array_filter(
+                array_map('strval', (array) $moduleMajors),
+                fn(string $major): bool => $major !== ''
+            )));
+        }
+        return array_filter($mapping);
     }
 
     /**

--- a/app/src/Misc/SupportedModulesManager.php
+++ b/app/src/Misc/SupportedModulesManager.php
@@ -10,6 +10,9 @@ class SupportedModulesManager
 
     private array $cmsMajorToBranches = [];
 
+    // Repos miscategorised upstream as misc that are actually regular installable modules.
+    private const REGULAR_OVERRIDES = ['silverstripe-non-blocking-sessions', 'doorman'];
+
     public function getModules(): array
     {
         if (!empty($this->modules)) {
@@ -18,14 +21,14 @@ class SupportedModulesManager
         $repoData = MetaData::getAllRepositoryMetaData();
         $this->modules = [
             'regular' => [],
-            'tooling' => [],
+            'other' => [],
         ];
         // Adapt json keys to the keys used in rhino
         $types = [
             MetaData::CATEGORY_SUPPORTED => 'regular',
-            MetaData::CATEGORY_WORKFLOW => 'tooling',
-            MetaData::CATEGORY_TOOLING => 'tooling',
-            MetaData::CATEGORY_MISC => 'tooling',
+            MetaData::CATEGORY_WORKFLOW => 'other',
+            MetaData::CATEGORY_TOOLING => 'other',
+            MetaData::CATEGORY_MISC => 'other',
         ];
         foreach ($types as $category => $type) {
             foreach ($repoData[$category] as $module) {
@@ -34,6 +37,9 @@ class SupportedModulesManager
                     continue;
                 }
                 [$account, $repo] = explode('/', $module['github']);
+                if (in_array($repo, self::REGULAR_OVERRIDES, true)) {
+                    $type = 'regular';
+                }
                 $this->modules[$type][$account] ??= [];
                 $this->modules[$type][$account][] = $repo;
                 $this->cmsMajorToBranches[$repo] = $majorVersionMapping;

--- a/app/src/Processors/AbstractProcessor.php
+++ b/app/src/Processors/AbstractProcessor.php
@@ -66,11 +66,7 @@ abstract class AbstractProcessor
         string $runName
     ): string {
         // will retrieve the most recent completed run
-        $suffix = '';
-        if ($runName === 'Merge-up') {
-            $suffix = '&per_page=100';
-        }
-        $path = "/repos/$account/$repo/actions/runs?paginate=0&branch=$branch" . $suffix;
+        $path = "/repos/$account/$repo/actions/runs?paginate=0&per_page=100&branch=$branch";
         $json = $requester->fetch($path, '', $account, $repo, $refetch);
         $conclusion = 'no-status'; // not a real conclusion type, I made this up
         foreach ($json->root->workflow_runs ?? [] as $run) {

--- a/app/src/Processors/BuildsProcessor.php
+++ b/app/src/Processors/BuildsProcessor.php
@@ -79,6 +79,10 @@ EOT;
             } else {
                 if (count($majorBranches)) {
                     $currMajBrn = $majorBranches[0];
+                    // No minor branches — map major branches into minor-column slots so badges are fetched.
+                    $nextMinBrn = $majorBranches[0];
+                    $pmMinBrn   = $majorBranches[1] ?? '';
+                    $pmPatBrn   = $majorBranches[2] ?? '';
                 } else {
                     continue;
                 }
@@ -134,6 +138,7 @@ EOT;
             $row = [
                 'account' => $account,
                 'repo' => $repo,
+                'type' => $moduleType,
 
                 // next major
                 'nextMajBrn' => $nextMajBrn ? ($nextMajBrn . '.x-dev') : '',
@@ -195,7 +200,7 @@ EOT;
         $manager = new SupportedModulesManager();
         $modules = $manager->getModules();
         $varsList = [];
-        foreach (['regular', 'tooling'] as $moduleType) {
+        foreach (['regular', 'other'] as $moduleType) {
             foreach ($modules[$moduleType] as $account => $repos) {
                 foreach ($repos as $repo) {
                     $varsList[] = [$account, $repo, $moduleType];

--- a/app/tests/Misc/CmsBuildsManagerTest.php
+++ b/app/tests/Misc/CmsBuildsManagerTest.php
@@ -2,6 +2,7 @@
 
 namespace App\Tests\Misc;
 
+use App\Misc\CmsBuildsManager;
 use DateTimeImmutable;
 use SilverStripe\Dev\SapphireTest;
 
@@ -103,6 +104,99 @@ PHP2,
         $repos = $manager->getVisibleRepoNames();
         $this->assertContains('silverstripe-admin', $repos);
         $this->assertContains('silverstripe-staticpublishqueue', $repos);
+    }
+
+    public function testSupportedModuleMajorMappingsProvideFallbackVisibilityAndBranchMappings(): void
+    {
+        $manager = new FixedDateCmsBuildsManager(
+            new DateTimeImmutable('2026-03-23 Pacific/Auckland'),
+            $this->getDefaultLocksteppedRepos(),
+            [
+                'silverstripe-config' => [
+                    '5' => ['2'],
+                    '6' => ['3'],
+                ],
+                'startup-theme' => [
+                    '6' => ['1'],
+                ],
+                'legacy-only-module' => [
+                    '4' => ['9'],
+                ],
+            ]
+        );
+        $manager->load(new ArrayRequester($this->getFiles()), false);
+
+        $repos = $manager->getVisibleRepoNames();
+        $this->assertContains('silverstripe-config', $repos);
+        $this->assertContains('startup-theme', $repos);
+        $this->assertNotContains('legacy-only-module', $repos);
+
+        $this->assertSame(['3'], $manager->getMappedMinorBranches('silverstripe-config', '6.1'));
+        $this->assertSame(['2'], $manager->getMappedMinorBranches('silverstripe-config', '5.4'));
+        $this->assertSame(['3'], $manager->getMappedMajorBranches('silverstripe-config', '6'));
+        $this->assertSame(['2'], $manager->getMappedMajorBranches('silverstripe-config', '5'));
+        $this->assertSame(['1'], $manager->getMappedMinorBranches('startup-theme', '6.1'));
+        $this->assertSame([], $manager->getMappedMinorBranches('startup-theme', '5.4'));
+    }
+
+    public function testLoadSupportedModuleMajorMappingsExcludesNullPackagistRepos(): void
+    {
+        $rawItems = [
+            // Has packagist — should be included
+            [
+                'github' => 'silverstripe/silverstripe-config',
+                'packagist' => 'silverstripe/config',
+                'majorVersionMapping' => ['6' => ['3'], '5' => ['2']],
+            ],
+            // packagist is null — should be excluded (e.g. webpack-config, eslint-config)
+            [
+                'github' => 'silverstripe/webpack-config',
+                'packagist' => null,
+                'majorVersionMapping' => ['6' => ['3'], '5' => ['2']],
+            ],
+            // packagist key absent — should also be excluded
+            [
+                'github' => 'silverstripe/eslint-config',
+                'majorVersionMapping' => ['6' => ['1']],
+            ],
+            // hardcoded exclusion: skeleton template repo with a packagist entry
+            [
+                'github' => 'silverstripe/silverstripe-module',
+                'packagist' => 'silverstripe-module/skeleton',
+                'majorVersionMapping' => ['5' => ['5']],
+            ],
+        ];
+
+        $date = new DateTimeImmutable('2026-03-23 Pacific/Auckland');
+        $manager = new class ($date, $rawItems) extends CmsBuildsManager {
+            public function __construct(
+                private DateTimeImmutable $currentDate,
+                private array $rawItems
+            ) {
+            }
+
+            protected function fetchAllRepositoryMetaData(bool $refetch): array
+            {
+                return $this->rawItems;
+            }
+
+            protected function loadLocksteppedRepos(bool $refetch): array
+            {
+                return [];
+            }
+
+            protected function getCurrentDateNZT(): DateTimeImmutable
+            {
+                return $this->currentDate;
+            }
+        };
+        $manager->load(new ArrayRequester($this->getFiles()), false);
+
+        $repos = $manager->getVisibleRepoNames();
+        $this->assertContains('silverstripe-config', $repos);
+        $this->assertNotContains('webpack-config', $repos);
+        $this->assertNotContains('eslint-config', $repos);
+        $this->assertNotContains('silverstripe-module', $repos);
     }
 
     public function testGetMappedMinorBranchesForNonLocksteppedRepo(): void

--- a/app/tests/Misc/FixedDateCmsBuildsManager.php
+++ b/app/tests/Misc/FixedDateCmsBuildsManager.php
@@ -15,8 +15,18 @@ class FixedDateCmsBuildsManager extends CmsBuildsManager
      */
     public function __construct(
         private DateTimeImmutable $currentDate,
-        private array $locksteppedRepos = []
+        private array $locksteppedRepos = [],
+        private array $supportedModuleMajorMappings = []
     ) {
+    }
+
+    /**
+     * Prevents any real network call; raw-metadata-dependent paths are bypassed by the
+     * loadLocksteppedRepos / loadSupportedModuleMajorMappings overrides below.
+     */
+    protected function fetchAllRepositoryMetaData(bool $refetch): array
+    {
+        return [];
     }
 
     /**
@@ -27,6 +37,16 @@ class FixedDateCmsBuildsManager extends CmsBuildsManager
     protected function loadLocksteppedRepos(bool $refetch): array
     {
         return $this->locksteppedRepos;
+    }
+
+    /**
+     * Returns injected supported-module major mappings instead of calling the supported-modules API.
+     *
+     * @return array<string, array<string, string[]>>
+     */
+    protected function loadSupportedModuleMajorMappings(bool $refetch): array
+    {
+        return $this->supportedModuleMajorMappings;
     }
 
     /**


### PR DESCRIPTION
Issue https://github.com/silverstripe/rhino/issues/53

Realised after deployment to UAT there was bunch of stuff not working great with both the build tables, so have fixed up:

1. cms-builds previously included some of modules that weren't relevant to a regular cms install like eslint-config, they no longer show (though still show on builds table)
2. cms-builds was missing some relevant modules for a CMS install like silverstripe-config and doorman
3. Added a new column on the builds table `type` which shows either `regular` or `other` (and changed 'tooling' to 'other' since 'tooling' is pretty confusing in this context). All the 'regular' modules show on the cms-builds table but none of the 'other' modules.
4. Major-only repos now show CI badges - repos with only major branches (e.g. supported-modules, cow) previously showed no badge at all.