### PR TITLE
FIX Use correct key

### DIFF
--- a/app/src/Misc/SupportedModulesManager.php
+++ b/app/src/Misc/SupportedModulesManager.php
@@ -37,11 +37,11 @@ class SupportedModulesManager
                     continue;
                 }
                 [$account, $repo] = explode('/', $module['github']);
-                if (in_array($repo, self::REGULAR_OVERRIDES, true)) {
-                    $type = 'regular';
-                }
-                $this->modules[$type][$account] ??= [];
-                $this->modules[$type][$account][] = $repo;
+                // Use a separate variable - overwriting $type would leak 'regular' onto
+                // every subsequent repo in the same category
+                $moduleType = in_array($repo, self::REGULAR_OVERRIDES, true) ? 'regular' : $type;
+                $this->modules[$moduleType][$account] ??= [];
+                $this->modules[$moduleType][$account][] = $repo;
                 $this->cmsMajorToBranches[$repo] = $majorVersionMapping;
             }
         }

--- a/app/src/Processors/IssuesProcessor.php
+++ b/app/src/Processors/IssuesProcessor.php
@@ -53,7 +53,7 @@ EOT;
         $rows = [];
 
         $varsList = [];
-        foreach (['regular', 'tooling'] as $moduleType) {
+        foreach (['regular', 'other'] as $moduleType) {
             foreach ($modules[$moduleType] as $account => $repos) {
                 foreach ($repos as $repo) {
                     $varsList[] = [$account, $repo];

--- a/app/src/Processors/MergeUpsProcessor.php
+++ b/app/src/Processors/MergeUpsProcessor.php
@@ -68,7 +68,7 @@ EOT;
         $modules = $manager->getModules();
 
         $repoList = [];
-        foreach (['regular', 'tooling'] as $moduleType) {
+        foreach (['regular', 'other'] as $moduleType) {
             foreach ($modules[$moduleType] as $account => $repos) {
                 foreach ($repos as $repo) {
                     $repoList[] = [$account, $repo];
@@ -161,8 +161,9 @@ EOT;
                     // Add actual column data here
                     foreach ($columns as $col) {
                         // If we have no branches left, or the branch is the wrong type for this column, skip the column
+                        $branch = $branches[$branchIndex] ?? '';
                         $wrongType = $col !== $colPrefix && !str_contains($col, 'NextMin')
-                            && !preg_match('/[0-9]+\.[0-9]/', $branches[$branchIndex]);
+                            && !preg_match('/[0-9]+\.[0-9]/', $branch);
                         if (!isset($branches[$branchIndex]) || $wrongType) {
                             $row[$col] = str_ends_with($col, 'status') ? $nothingToMerge : '';
                             continue;

--- a/app/src/Processors/OpenPrsProcessor.php
+++ b/app/src/Processors/OpenPrsProcessor.php
@@ -56,7 +56,7 @@ EOT;
         $rows = [];
 
         $varsList = [];
-        foreach (['regular', 'tooling'] as $moduleType) {
+        foreach (['regular', 'other'] as $moduleType) {
             foreach ($modules[$moduleType] as $account => $repos) {
                 foreach ($repos as $repo) {
                     $varsList[] = [$account, $repo, $moduleType];

--- a/app/src/Processors/RecentMergedPrsProcessor.php
+++ b/app/src/Processors/RecentMergedPrsProcessor.php
@@ -80,7 +80,7 @@ class RecentMergedPrsProcessor extends AbstractProcessor
         $rows = [];
 
         $varsList = [];
-        foreach (['regular', 'tooling'] as $moduleType) {
+        foreach (['regular', 'other'] as $moduleType) {
             foreach ($modules[$moduleType] as $account => $repos) {
                 foreach ($repos as $repo) {
                     $varsList[] = [$account, $repo, $moduleType];

--- a/app/src/Processors/ReleasesProcessor.php
+++ b/app/src/Processors/ReleasesProcessor.php
@@ -90,7 +90,7 @@ EOT;
         $rows = [];
 
         $varsList = [];
-        foreach (['regular', 'tooling'] as $moduleType) {
+        foreach (['regular', 'other'] as $moduleType) {
             foreach ($modules[$moduleType] as $account => $repos) {
                 foreach ($repos as $repo) {
                     if (in_array("{$account}/{$repo}", self::EXCLUDE_MODULES)) {
@@ -431,7 +431,6 @@ EOT;
     // TODO: Put this into PullRequestUtil
     private function isDevFile(stdClass $file): bool
     {
-        // possiblly should treat .scrutinizer as 'tooling'
         $path = $file->filename;
         $paths = [
             '.codeclimate.yml',


### PR DESCRIPTION
Issue https://github.com/silverstripe/rhino/issues/56

- Changes 'tooling' key to 'other' in various processors
- Fixes a couple of bugs that prevented jobs from running
- Removes stale 'tooling' comment

Have run all jobs locally, all tables are being correctly generated from github data



